### PR TITLE
Modify default useradd behaviour.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -64,6 +64,9 @@ RUN mkdir -p /boot /sysroot /var/home && \
     ln -s /var/usrlocal /usr/local && \
     ln -s /var/srv /srv
 
+# Update useradd default to /var/home instead of /home for User Creation
+RUN sed -i 's|^HOME=.*|HOME=/var/home|' /etc/default/useradd
+
 # Setup a temporary root passwd (changeme) for dev purposes
 # TODO: Replace this for a more robust option when in prod
 RUN usermod -p '$6$AJv9RHlhEXO6Gpul$5fvVTZXeM0vC03xckTIjY8rdCofnkKSzvF5vEzXDKAby5p3qaOGTHDypVVxKsCE3CbZz7C3NXnbpITrEUvN/Y/' root && \


### PR DESCRIPTION
This should probably fix the permission errors by setting the default user home at /var/home instead.